### PR TITLE
fix: make arrow routing orthogonal and fix swimlane border paths in 1…

### DIFF
--- a/architecture/diagrams/use-cases/driver-availability-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/driver-availability-use-case.drawio.svg
@@ -147,31 +147,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App (Driver)</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">driver-availability-process-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -220,11 +220,11 @@
 <path d="M 130 100.0 L 123.5 104.7 L 123.5 95.3 Z" fill="rgb(0,0,0)"/>
 <path d="M 250 100.0 L 290 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 290 100.0 L 283.5 104.7 L 283.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 350.0 140 L 360.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 350 140 L 350 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 360.0 260 L 354.8 253.9 L 364.1 253.2 Z" fill="rgb(0,0,0)"/>
 <rect x="232.5" y="182.0" width="245" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="355.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /drivers/{id}/status (online)</text>
-<path d="M 360.0 340 L 365.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 360 340 L 360 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 365.0 460 L 360.0 453.7 L 369.4 453.3 Z" fill="rgb(0,0,0)"/>
 <rect x="250.5" y="382.0" width="224" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="362.5" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /drivers/{id}/availability</text>
@@ -246,7 +246,7 @@
 <path d="M 730 100.0 L 722.7 103.3 L 724.6 94.1 Z" fill="rgb(0,0,0)"/>
 <path d="M 850 100.0 L 900 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 900 100.0 L 893.5 104.7 L 893.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 605.0 540 L 610.0 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 605 540 L 605 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 610.0 860 L 605.2 853.6 L 614.6 853.5 Z" fill="rgb(0,0,0)"/>
 <rect x="544.5" y="682.0" width="126" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="607.5" y="692.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /notification</text>

--- a/architecture/diagrams/use-cases/driver-payout-earnings-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/driver-payout-earnings-use-case.drawio.svg
@@ -142,37 +142,37 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App (Driver)</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">finish-ride-process-api / Payout Job</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">square-system-api</text>
 </g>
 <path d="M 30 1000 L 0 1000 L 0 1200 L 30 1200" fill="#fde8e7" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 1000 L 1100 1000 L 1100 1200 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 1000 L 1100 1000 L 1100 1200 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 1000 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,1100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -219,17 +219,17 @@
 <text x="900" y="1110" text-anchor="middle" font-family="Helvetica" font-size="11" fill="rgb(0,0,0)">(Payout Deposited)</text>
 <path d="M 90 100.0 L 130 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 130 100.0 L 123.5 104.7 L 123.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 190.0 140 L 210.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 190 140 L 190 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 210.0 260 L 204.3 254.4 L 213.6 252.8 Z" fill="rgb(0,0,0)"/>
 <rect x="81.0" y="182.0" width="238" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="200.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">GET /drivers/{id}/earnings/summary</text>
 <path d="M 210.0 340 L 210.0 200.0 L 530.0 200.0 L 530.0 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 530.0 60 L 534.7 66.5 L 525.3 66.5 Z" fill="rgb(0,0,0)"/>
-<path d="M 230.0 530 L 210.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 230 530 L 230 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 210.0 660 L 206.3 652.9 L 215.6 654.3 Z" fill="rgb(0,0,0)"/>
 <rect x="146.5" y="577.0" width="147" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="220.0" y="587.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /driver-earnings</text>
-<path d="M 550.0 530 L 540.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 550 530 L 550 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 540.0 660 L 535.8 653.2 L 545.2 653.9 Z" fill="rgb(0,0,0)"/>
 <rect x="447.0" y="577.0" width="196" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="545.0" y="587.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">GET /drivers/payouts/pending</text>
@@ -243,15 +243,15 @@
 <path d="M 1045.0 75 L 1049.7 81.5 L 1040.3 81.5 Z" fill="rgb(0,0,0)"/>
 <rect x="836.0" y="282.0" width="98" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="885.0" y="292.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">No (roll over)</text>
-<path d="M 870.0 540 L 880.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 870 540 L 870 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 880.0 660 L 874.8 653.9 L 884.1 653.2 Z" fill="rgb(0,0,0)"/>
 <rect x="805.0" y="582.0" width="140" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="875.0" y="592.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /driver-payouts</text>
-<path d="M 870.0 540 L 885.0 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 870 540 L 870 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 885.0 860 L 880.0 853.8 L 889.4 853.3 Z" fill="rgb(0,0,0)"/>
 <rect x="832.0" y="682.0" width="91" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="877.5" y="692.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /payouts</text>
-<path d="M 870.0 540 L 900.0 1060" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 870 540 L 870 600 L 900 600 L 900 1060" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 900.0 1060 L 894.9 1053.8 L 904.3 1053.3 Z" fill="rgb(0,0,0)"/>
 <rect x="822.0" y="782.0" width="126" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="885.0" y="792.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /notification</text>

--- a/architecture/diagrams/use-cases/driver-sign-up-onboarding-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/driver-sign-up-onboarding-use-case.drawio.svg
@@ -211,49 +211,49 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">sign-up-user-process-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">okta-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">square-system-api</text>
 </g>
 <path d="M 30 1000 L 0 1000 L 0 1200 L 30 1200" fill="#fde8e7" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 1000 L 1100 1000 L 1100 1200 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 1000 L 1100 1000 L 1100 1200 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 1000 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,1100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 1200 L 0 1200 L 0 1400 L 30 1400" fill="#fff3e0" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 1200 L 1100 1200 L 1100 1400 L 30 1400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 1200 L 1100 1200 L 1100 1400 L 30 1400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 1200 L 30 1400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,1300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">email-system-api</text>
 </g>
 <path d="M 30 1400 L 0 1400 L 0 1600 L 30 1600" fill="#e8e6f0" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 1400 L 1100 1400 L 1100 1600 L 30 1600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 1400 L 1100 1400 L 1100 1600 L 30 1600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 1400 L 30 1600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,1500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -332,15 +332,15 @@
 <path d="M 350.0 460 L 345.3 453.5 L 354.7 453.5 Z" fill="rgb(0,0,0)"/>
 <rect x="311.5" y="382.0" width="77" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="350.0" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /users</text>
-<path d="M 350.0 540 L 370.0 650" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 350 540 L 350 650" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 370.0 650 L 364.2 644.5 L 373.5 642.8 Z" fill="rgb(0,0,0)"/>
 <rect x="321.5" y="577.0" width="77" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="360.0" y="587.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /users</text>
-<path d="M 350.0 540 L 370.0 850" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 350 540 L 350 850" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 370.0 850 L 364.9 843.8 L 374.3 843.2 Z" fill="rgb(0,0,0)"/>
 <rect x="307.5" y="677.0" width="105" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="360.0" y="687.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /customers</text>
-<path d="M 350.0 540 L 360.0 1060" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 350 540 L 350 1060" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 360.0 1060 L 355.2 1053.6 L 364.6 1053.4 Z" fill="rgb(0,0,0)"/>
 <rect x="309.5" y="782.0" width="91" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="355.0" y="792.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /drivers</text>
@@ -348,15 +348,15 @@
 <path d="M 560.0 1260 L 555.3 1253.5 L 564.7 1253.5 Z" fill="rgb(0,0,0)"/>
 <rect x="413.0" y="882.0" width="84" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="455.0" y="892.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /emails</text>
-<path d="M 560.0 1340 L 550.0 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 560 1340 L 560 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 550.0 60 L 554.8 66.4 L 545.3 66.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 610 100.0 L 650 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 650 100.0 L 643.5 104.7 L 643.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 710.0 140 L 715.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 710 140 L 710 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 715.0 260 L 710.0 253.7 L 719.4 253.3 Z" fill="rgb(0,0,0)"/>
 <rect x="621.5" y="182.0" width="182" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="712.5" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /drivers/{id}/vehicle</text>
-<path d="M 870.0 140 L 875.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 870 140 L 870 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 875.0 260 L 870.0 253.7 L 879.4 253.3 Z" fill="rgb(0,0,0)"/>
 <rect x="774.5" y="182.0" width="196" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="872.5" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /drivers/{id}/documents</text>
@@ -372,7 +372,7 @@
 <path d="M 970.0 1060 L 965.3 1053.5 L 974.7 1053.5 Z" fill="rgb(0,0,0)"/>
 <rect x="879.0" y="782.0" width="182" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="970.0" y="792.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /drivers/{id}/status</text>
-<path d="M 970.0 540 L 980.0 1460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 970 540 L 970 1460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 980.0 1460 L 975.2 1453.6 L 984.6 1453.5 Z" fill="rgb(0,0,0)"/>
 <rect x="912.0" y="982.0" width="126" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="975.0" y="992.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /notification</text>

--- a/architecture/diagrams/use-cases/help-support-dispute-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/help-support-dispute-use-case.drawio.svg
@@ -114,31 +114,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">salesforce-system-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">square-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -180,7 +180,7 @@
 <path d="M 310 100.0 L 303.5 104.7 L 303.5 95.3 Z" fill="rgb(0,0,0)"/>
 <path d="M 470 100.0 L 520 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 520 100.0 L 513.5 104.7 L 513.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 580.0 140 L 590.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 580 140 L 580 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 590.0 260 L 584.8 253.9 L 594.1 253.2 Z" fill="rgb(0,0,0)"/>
 <rect x="511.5" y="182.0" width="147" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="585.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /support/tickets</text>
@@ -202,7 +202,7 @@
 <path d="M 870.0 50 L 874.7 56.5 L 865.3 56.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 960 90.0 L 1010 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 1010 100.0 L 1002.7 103.3 L 1004.6 94.1 Z" fill="rgb(0,0,0)"/>
-<path d="M 860.0 940 L 870.0 50" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 860 940 L 860 50" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 870.0 50 L 874.6 56.5 L 865.2 56.4 Z" fill="rgb(0,0,0)"/>
   </g>
 </svg>

--- a/architecture/diagrams/use-cases/notification-preferences-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/notification-preferences-use-case.drawio.svg
@@ -112,31 +112,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">email-system-api</text>
@@ -181,11 +181,11 @@
 <path d="M 490.0 60 L 494.7 66.5 L 485.3 66.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 560 100.0 L 620 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 620 100.0 L 613.5 104.7 L 613.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 690.0 140 L 720.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 690 140 L 690 200 L 720 200 L 720 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 720.0 260 L 713.9 254.9 L 723.0 252.6 Z" fill="rgb(0,0,0)"/>
 <rect x="558.0" y="182.0" width="294" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="705.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /users/{id}/notification-preferences</text>
-<path d="M 720.0 340 L 700.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 720 340 L 720 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 700.0 460 L 696.4 452.8 L 705.7 454.4 Z" fill="rgb(0,0,0)"/>
 <rect x="612.0" y="382.0" width="196" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="710.0" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /user-preferences/{id}</text>

--- a/architecture/diagrams/use-cases/payment-failure-handling-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/payment-failure-handling-use-case.drawio.svg
@@ -155,31 +155,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Process API (ride lifecycle)</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">square-system-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -232,7 +232,7 @@
 <path d="M 130 100.0 L 123.5 104.7 L 123.5 95.3 Z" fill="rgb(0,0,0)"/>
 <path d="M 210.0 140 L 210.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 210.0 260 L 205.3 253.5 L 214.7 253.5 Z" fill="rgb(0,0,0)"/>
-<path d="M 210.0 340 L 205.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 210 340 L 210 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 205.0 460 L 200.6 453.3 L 210.0 453.7 Z" fill="rgb(0,0,0)"/>
 <rect x="144.5" y="382.0" width="126" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="207.5" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /payment-link</text>
@@ -268,11 +268,11 @@
 <path d="M 575.0 660 L 570.3 653.5 L 579.7 653.5 Z" fill="rgb(0,0,0)"/>
 <rect x="660.5" y="482.0" width="154" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="737.5" y="492.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /payment-failures</text>
-<path d="M 900.0 340 L 910.0 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 900 340 L 900 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 910.0 860 L 905.2 853.6 L 914.6 853.4 Z" fill="rgb(0,0,0)"/>
 <rect x="842.0" y="582.0" width="126" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="905.0" y="592.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /notification</text>
-<path d="M 910.0 940 L 900.0 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 910 940 L 910 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 900.0 60 L 904.8 66.4 L 895.4 66.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 970 100.0 L 1020 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 1020 100.0 L 1013.5 104.7 L 1013.5 95.3 Z" fill="rgb(0,0,0)"/>

--- a/architecture/diagrams/use-cases/real-time-ride-tracking-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/real-time-ride-tracking-use-case.drawio.svg
@@ -119,31 +119,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App (Client)</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App (Driver)</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">google-maps-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -185,7 +185,7 @@
 <text x="790" y="917" text-anchor="middle" font-family="Helvetica" font-size="11" fill="rgb(0,0,0)">Alerts)</text>
 <path d="M 90 100.0 L 180 90.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 180 90.0 L 174.1 95.4 L 173.0 86.0 Z" fill="rgb(0,0,0)"/>
-<path d="M 260.0 340 L 255.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 260 340 L 260 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 255.0 460 L 250.6 453.3 L 260.0 453.7 Z" fill="rgb(0,0,0)"/>
 <rect x="163.0" y="382.0" width="189" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="257.5" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /drivers/{id}/location</text>
@@ -207,7 +207,7 @@
 <text x="640.0" y="292.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /rides/{id}/share</text>
 <path d="M 380 90.0 L 450 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 450 100.0 L 442.9 103.7 L 444.3 94.4 Z" fill="rgb(0,0,0)"/>
-<path d="M 790.0 940 L 770.0 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 790 940 L 790 60" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 770.0 60 L 774.8 66.4 L 765.4 66.6 Z" fill="rgb(0,0,0)"/>
 <rect x="734.5" y="482.0" width="91" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="780.0" y="492.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">Almost there!</text>

--- a/architecture/diagrams/use-cases/ride-cancellation-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/ride-cancellation-use-case.drawio.svg
@@ -135,37 +135,37 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">cancel-ride-process-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">square-system-api</text>
 </g>
 <path d="M 30 1000 L 0 1000 L 0 1200 L 30 1200" fill="#fde8e7" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 1000 L 1100 1000 L 1100 1200 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 1000 L 1100 1000 L 1100 1200 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 1000 L 30 1200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,1100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">push-notifications-system-api</text>
@@ -234,11 +234,11 @@
 <text x="602.5" y="684.5" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">With charge</text>
 <path d="M 530 500.0 L 700 500.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 700 500.0 L 693.5 504.7 L 693.5 495.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 760.0 540 L 770.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 760 540 L 760 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 770.0 660 L 764.8 653.9 L 774.1 653.2 Z" fill="rgb(0,0,0)"/>
 <rect x="705.5" y="582.0" width="119" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="765.0" y="592.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /rides/{id}</text>
-<path d="M 760.0 540 L 780.0 1060" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 760 540 L 760 1060" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 780.0 1060 L 775.1 1053.7 L 784.5 1053.4 Z" fill="rgb(0,0,0)"/>
 <rect x="707.0" y="782.0" width="126" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="770.0" y="792.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /notification</text>

--- a/architecture/diagrams/use-cases/ride-history-receipts-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/ride-history-receipts-use-case.drawio.svg
@@ -115,25 +115,25 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">google-maps-system-api</text>
@@ -185,11 +185,11 @@
 <path d="M 450.0 60 L 454.7 66.5 L 445.3 66.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 520 100.0 L 560 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 560 100.0 L 553.5 104.7 L 553.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 620.0 140 L 630.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 620 140 L 620 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 630.0 260 L 624.8 253.9 L 634.1 253.2 Z" fill="rgb(0,0,0)"/>
 <rect x="544.5" y="182.0" width="161" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="625.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">GET /rides/{id}/details</text>
-<path d="M 630.0 340 L 640.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 630 340 L 630 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 640.0 660 L 635.1 653.7 L 644.5 653.4 Z" fill="rgb(0,0,0)"/>
 <rect x="561.5" y="482.0" width="147" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="635.0" y="492.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">GET /routes/{ride_id}</text>
@@ -197,7 +197,7 @@
 <path d="M 780.0 60 L 784.7 66.5 L 775.3 66.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 860 100.0 L 900 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 900 100.0 L 893.5 104.7 L 893.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 960.0 140 L 970.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 960 140 L 960 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 970.0 260 L 964.8 253.9 L 974.1 253.2 Z" fill="rgb(0,0,0)"/>
 <rect x="884.5" y="182.0" width="161" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="965.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">GET /rides/{id}/receipt</text>

--- a/architecture/diagrams/use-cases/ride-pricing-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/ride-pricing-use-case.drawio.svg
@@ -126,31 +126,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">request-ride-process-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">google-maps-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
@@ -199,11 +199,11 @@
 <path d="M 350.0 260 L 345.3 253.5 L 354.7 253.5 Z" fill="rgb(0,0,0)"/>
 <rect x="205.0" y="182.0" width="140" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="275.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /rides/estimate</text>
-<path d="M 350.0 340 L 360.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 350 340 L 350 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 360.0 460 L 354.8 453.9 L 364.1 453.2 Z" fill="rgb(0,0,0)"/>
 <rect x="274.5" y="382.0" width="161" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="355.0" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /pricing/calculate</text>
-<path d="M 360.0 540 L 370.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 360 540 L 360 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 370.0 660 L 364.8 653.9 L 374.1 653.2 Z" fill="rgb(0,0,0)"/>
 <rect x="305.5" y="582.0" width="119" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="365.0" y="592.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /geolocation</text>
@@ -221,7 +221,7 @@
 <path d="M 840.0 50 L 844.7 56.5 L 835.3 56.5 Z" fill="rgb(0,0,0)"/>
 <rect x="682.5" y="272.0" width="105" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="735.0" y="282.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">Return estimate</text>
-<path d="M 630.0 530 L 615.0 945" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 630 530 L 630 945" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 615.0 945 L 610.5 938.4 L 619.9 938.7 Z" fill="rgb(0,0,0)"/>
 <rect x="552.5" y="719.5" width="140" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="622.5" y="729.5" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /fare-estimates</text>

--- a/architecture/diagrams/use-cases/ride-type-selection-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/ride-type-selection-use-case.drawio.svg
@@ -107,25 +107,25 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">request-ride-process-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
@@ -163,7 +163,7 @@
 <path d="M 350.0 260 L 345.3 253.5 L 354.7 253.5 Z" fill="rgb(0,0,0)"/>
 <rect x="205.0" y="182.0" width="140" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="275.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /rides/estimate</text>
-<path d="M 350.0 340 L 360.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 350 340 L 350 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 360.0 460 L 354.8 453.9 L 364.1 453.2 Z" fill="rgb(0,0,0)"/>
 <rect x="274.5" y="382.0" width="161" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="355.0" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /pricing/calculate</text>
@@ -181,7 +181,7 @@
 <text x="460.0" y="287.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">Return estimates per type</text>
 <path d="M 660 90.0 L 720 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 720 100.0 L 712.8 103.6 L 714.4 94.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 785.0 140 L 780.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 785 140 L 785 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 780.0 260 L 775.6 253.3 L 785.0 253.7 Z" fill="rgb(0,0,0)"/>
 <rect x="744.0" y="182.0" width="77" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="782.5" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">POST /rides</text>

--- a/architecture/diagrams/use-cases/user-profile-management-use-case.drawio.svg
+++ b/architecture/diagrams/use-cases/user-profile-management-use-case.drawio.svg
@@ -112,31 +112,31 @@
   <defs/>
   <g>
 <path d="M 30 0 L 0 0 L 0 200 L 30 200" fill="#f5f5f5" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 0 L 1100 0 L 1100 200 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 0 L 30 200" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,100)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">Mobile App</text>
 </g>
 <path d="M 30 200 L 0 200 L 0 400 L 30 400" fill="#e8f0fe" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 200 L 1100 200 L 1100 400 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 200 L 30 400" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,300)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">mobile-experience-api</text>
 </g>
 <path d="M 30 400 L 0 400 L 0 600 L 30 600" fill="#e8f5e6" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 400 L 1100 400 L 1100 600 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 400 L 30 600" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,500)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">okta-system-api</text>
 </g>
 <path d="M 30 600 L 0 600 L 0 800 L 30 800" fill="#fff8e1" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 600 L 1100 600 L 1100 800 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 600 L 30 800" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,700)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">square-system-api</text>
 </g>
 <path d="M 30 800 L 0 800 L 0 1000 L 30 1000" fill="#f0e8f4" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-<path d="30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+<path d="M 30 800 L 1100 800 L 1100 1000 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <path d="M 30 800 L 30 1000" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
 <g transform="translate(15,900)">
   <text text-anchor="middle" font-family="Helvetica" font-size="12" transform="rotate(-90)" fill="rgb(0,0,0)">db-system-api</text>
@@ -181,19 +181,19 @@
 <path d="M 440.0 60 L 444.7 66.5 L 435.3 66.5 Z" fill="rgb(0,0,0)"/>
 <path d="M 500 100.0 L 560 100.0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 560 100.0 L 553.5 104.7 L 553.5 95.3 Z" fill="rgb(0,0,0)"/>
-<path d="M 620.0 140 L 630.0 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 620 140 L 620 260" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 630.0 260 L 624.8 253.9 L 634.1 253.2 Z" fill="rgb(0,0,0)"/>
 <rect x="537.5" y="182.0" width="175" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="625.0" y="192.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /users/{id}/profile</text>
-<path d="M 630.0 340 L 640.0 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 630 340 L 630 460" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 640.0 460 L 634.8 453.9 L 644.1 453.2 Z" fill="rgb(0,0,0)"/>
 <rect x="575.5" y="382.0" width="119" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="635.0" y="392.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /users/{id}</text>
-<path d="M 630.0 340 L 640.0 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 630 340 L 630 660" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 640.0 660 L 635.1 653.7 L 644.5 653.4 Z" fill="rgb(0,0,0)"/>
 <rect x="561.5" y="482.0" width="147" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="635.0" y="492.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /customers/{id}</text>
-<path d="M 630.0 340 L 640.0 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+<path d="M 630 340 L 630 860" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
 <path d="M 640.0 860 L 635.2 853.6 L 644.6 853.4 Z" fill="rgb(0,0,0)"/>
 <rect x="575.5" y="582.0" width="119" height="14" fill="rgb(255,255,255)" stroke="none"/>
 <text x="635.0" y="592.0" text-anchor="middle" font-family="Helvetica" font-size="10" fill="rgb(0,0,0)">PATCH /users/{id}</text>


### PR DESCRIPTION
…2 use-case diagrams

- Fix missing M prefix in swimlane border path data (was causing invisible swimlane borders in strict SVG renderers)
- Convert diagonal cross-lane arrows to orthogonal L-shaped routes (go vertical to lane boundary, then horizontal, then vertical to target) so flow is easy to trace visually
- Snap near-vertical arrows (x-diff ≤ 20px) to true vertical lines
- All 13 diagrams remain valid XML

Agent-Logs-Url: https://github.com/RideXpress/docs/sessions/4f83d3dd-f139-4ab5-9ea7-8745637c4810